### PR TITLE
feat: allow to hide badges in the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Types of changes
 
 ## [unreleased]
 
+### Added
+
+-   [allow to hide badges in the list](https://github.com/Talend/ui-faceted-search/pull/11)
+
 ## [1.0.1]
 
 ### Fixed

--- a/src/components/AddFacetPopover/AddFacetPopover.component.js
+++ b/src/components/AddFacetPopover/AddFacetPopover.component.js
@@ -190,9 +190,13 @@ const getCategories = badgesDefinitions => {
 };
 
 const getScreens = (badgesDefinitions, filterValue) => {
-	const categories = getCategories(badgesDefinitions);
+	const visibleBadges = badgesDefinitions.filter(
+		badgeDefinition => badgeDefinition.metadata.isAvailableForFacetList !== false,
+	);
 
-	const badgesWithoutCategory = badgesDefinitions.filter(
+	const categories = getCategories(visibleBadges);
+
+	const badgesWithoutCategory = visibleBadges.filter(
 		badgeDefinition => !badgeDefinition.metadata.category,
 	);
 

--- a/src/components/AddFacetPopover/AddFacetPopver.component.test.js
+++ b/src/components/AddFacetPopover/AddFacetPopver.component.test.js
@@ -97,12 +97,7 @@ describe('AddFacetPopover', () => {
 				.simulate('change', { target: { value: 'connection' } });
 		});
 		wrapper.update();
-		expect(
-			wrapper
-				.find('input')
-				.first()
-				.prop('value'),
-		).toBe('connection');
+		expect(wrapper.find('input').first().prop('value')).toBe('connection');
 		expect(wrapper.find('button[aria-label="Connection name"]')).toHaveLength(1);
 	});
 	it('should reset the badge rows when the filter is reset', () => {
@@ -119,18 +114,10 @@ describe('AddFacetPopover', () => {
 		const wrapper = mount(<AddFacetPopover {...props} />);
 		// Then
 		act(() => {
-			wrapper
-				.find('button[aria-label="Remove filter"]')
-				.first()
-				.simulate('mouseDown');
+			wrapper.find('button[aria-label="Remove filter"]').first().simulate('mouseDown');
 		});
 		wrapper.update();
-		expect(
-			wrapper
-				.find('input')
-				.first()
-				.prop('value'),
-		).toBe('');
+		expect(wrapper.find('input').first().prop('value')).toBe('');
 		expect(wrapper.find('button[aria-label="Name"]')).toHaveLength(1);
 		expect(wrapper.find('button[aria-label="Connection name"]')).toHaveLength(1);
 	});
@@ -203,12 +190,7 @@ describe('AddFacetPopover', () => {
 		wrapper.update();
 		expect(wrapper.find('button.tc-add-facet-popover-row')).toHaveLength(0);
 		expect(wrapper.find('span').first()).toHaveLength(1);
-		expect(
-			wrapper
-				.find('span')
-				.first()
-				.text(),
-		).toBe('No result found');
+		expect(wrapper.find('span').first().text()).toBe('No result found');
 	});
 	it('should render an disabled row if badgePerFacet is exceeded', () => {
 		// Given

--- a/stories/badgesDefinitions.js
+++ b/stories/badgesDefinitions.js
@@ -9,9 +9,28 @@ export const badgeName = {
 		type: 'text',
 	},
 	metadata: {
+		isAvailableForFacetList: true,
 		badgePerFacet: 'N',
 		entitiesPerBadge: '1',
 		operators: ['containsIgnoreCase', 'equals', 'notEquals', 'match a regexp'],
+	},
+};
+
+export const badgeAll = {
+	properties: {
+		attribute: 'all',
+		initialOperatorOpened: true,
+		initialValueOpened: false,
+		label: 'All',
+		operator: {},
+		operators: [],
+		type: 'text',
+	},
+	metadata: {
+		isAvailableForFacetList: false,
+		badgePerFacet: '1',
+		entitiesPerBadge: '1',
+		operators: ['containsIgnoreCase'],
 	},
 };
 

--- a/stories/facetedSearch.stories.js
+++ b/stories/facetedSearch.stories.js
@@ -16,6 +16,7 @@ import { createBadgesDict, getBadgesFromDict } from '../src/dictionary/badge.dic
 import {
 	badgeConnectionType,
 	badgeName,
+	badgeAll,
 	badgePrice,
 	badgeValid,
 	badgeEmpty,
@@ -31,6 +32,7 @@ import {
 } from './badgesDefinitions';
 
 const badgesDefinitions = [
+	badgeAll,
 	badgeName,
 	badgeConnectionType,
 	badgeTags,
@@ -69,6 +71,32 @@ const callbacks = {
 			]),
 		),
 };
+
+const badgesWithAll = {
+	badges: [
+		{
+			properties: {
+				attribute: 'all',
+				initialOperatorOpened: false,
+				initialValueOpened: false,
+				label: 'All',
+				operator: { label: 'Contains', name: 'containsIgnoreCase', iconName: 'contains' },
+				operators: [],
+				type: 'text',
+				value: 'test',
+			},
+			metadata: {
+				isAvailableForFacetList: false,
+				badgePerFacet: 'N',
+				entitiesPerBadge: '1',
+				operators: ['containsIgnoreCase'],
+				badgeId: 'all-b6c04e3d-1d72-4aca-9565-09d206f76d88',
+				isInCreation: false,
+			},
+		},
+	],
+};
+
 const badgesFaceted = {
 	badges: [
 		{
@@ -189,6 +217,25 @@ storiesOf('FacetedSearch', module)
 							badgesFaceted={badgesFaceted}
 							onSubmit={action('onSubmit')}
 							callbacks={callbacks}
+						/>
+					))
+				}
+			</FacetedSearch.Faceted>
+		</div>
+	))
+	.add('initialized with a badge which is not visible in the list', () => (
+		<div>
+			<FacetedSearch.Faceted id="my-faceted-search">
+				{currentFacetedMode =>
+					(currentFacetedMode === FacetedSearch.constants.FACETED_MODE.ADVANCED && (
+						<FacetedSearch.AdvancedSearch onSubmit={action('onSubmit')} />
+					)) ||
+					(currentFacetedMode === FacetedSearch.constants.FACETED_MODE.BASIC && (
+						<FacetedSearch.BasicSearch
+							badgesDefinitions={badgesDefinitions}
+							badgesFaceted={badgesWithAll}
+							callbacks={callbacks}
+							onSubmit={action('onSubmit')}
 						/>
 					))
 				}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
On Inventory side, we would like to be able to have a facet to build a badge without having it in the list of available facets in the list

**What is the chosen solution to this problem?**
Add metadata to filter it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
