### PR TITLE
fix(TDC-3248): Styling issue on badges with multiple lengthy values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ Types of changes
 -   `Fixed` for any bug fixes.
 -   `Security` in case of vulnerabilities.
 
+## [unreleased]
+
+### Fixed
+
+-   [Styling issue on badges with multiple lengthy values](https://github.com/Talend/ui-faceted-search/pull/15)
+
 ## [1.1.0]
 
 ### Changed

--- a/src/components/Badges/BadgeFaceted/BadgeFaceted.scss
+++ b/src/components/Badges/BadgeFaceted/BadgeFaceted.scss
@@ -1,14 +1,12 @@
-$width-operator-badge: 27rem;
-$width-label-badge: 23.5rem;
-
 .tc-badge-faceted {
 	padding: $padding-smaller $padding-small $padding-smaller $padding-small;
-	max-width: none;
+	max-width: 35em;
 
 	:global(.tc-badge-button) {
 		max-width: none;
 	}
 	:global(.tc-badge-button:first-child) {
+		flex-grow: 1;
 		padding-top: 0;
 		margin: 0;
 		> span {
@@ -18,12 +16,12 @@ $width-label-badge: 23.5rem;
 
 	:global(.tc-badge-delete-icon) {
 		align-self: center;
+		padding-left: $padding-small;
 	}
 
 	&-overlay {
 		align-items: center;
 		display: flex;
-		max-width: $width-label-badge;
 		& > button {
 			font-style: italic;
 			padding: 0;

--- a/src/components/Badges/BadgeOperator/BadgeOperator.scss
+++ b/src/components/Badges/BadgeOperator/BadgeOperator.scss
@@ -23,8 +23,10 @@ $circle-size-small: 1.8rem !default;
 			padding: 0;
 			text-decoration: none;
 			text-transform: none;
+			> span {
+				padding: 0 $padding-smaller;
+			}
 			> svg {
-				margin: 0;
 			}
 		}
 	}

--- a/src/components/Badges/BadgeOperator/BadgeOperator.scss
+++ b/src/components/Badges/BadgeOperator/BadgeOperator.scss
@@ -3,11 +3,9 @@ $circle-size-small: 1.8rem !default;
 
 .tc-badge-operator {
 	&-small {
-		width: $circle-size-small;
 		height: $circle-size-small;
 	}
 	&-large {
-		width: $circle-size-large;
 		height: $circle-size-large;
 	}
 	align-items: center;
@@ -25,6 +23,9 @@ $circle-size-small: 1.8rem !default;
 			padding: 0;
 			text-decoration: none;
 			text-transform: none;
+			> svg {
+				margin: 0;
+			}
 		}
 	}
 	&-popover {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Faceted search badges which contain multiple lengthy values result in a styling issue where the remove button overlays the badge values. The issue can be seen in the screenshot below.

![TDC-3248](https://user-images.githubusercontent.com/66147232/101648069-bdfdb600-3a39-11eb-9e32-fa2e3c88a6bd.png)

**What is the chosen solution to this problem?**
Allow the badge value container to grow as required within the flex grid. Some additional padding added to the badge delete button. Minor improvements are also made to the styling of the badge operator container. 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

**[ ] This PR introduces a breaking change**

