### PR TITLE
feat(faceted-search): Support custom/no sort of badge definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ Types of changes
 
 ## [unreleased]
 
+## [1.2.0]
+
+### Added
+
+- [Added](https://github.com/Talend/ui-faceted-search/pull/17): Support custom/no sort of badge definitions
+
 ### Fixed
 
 -   [Styling issue on badges with multiple lengthy values](https://github.com/Talend/ui-faceted-search/pull/15)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-faceted-search",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Faceted search",
   "main": "lib/index.js",
   "mainSrc": "src/index.js",

--- a/src/components/AddFacetPopover/AddFacetPopver.component.test.js
+++ b/src/components/AddFacetPopover/AddFacetPopver.component.test.js
@@ -256,4 +256,39 @@ describe('AddFacetPopover', () => {
 		// Then
 		expect(wrapper.find('button[aria-label=""]')).toHaveLength(0);
 	});
+	it('should sort by label if no comparator provided', () => {
+		// Given
+		const props = {
+			badges,
+			badgesDefinitions,
+			id: 'my id',
+			onClick: jest.fn(),
+			t,
+		};
+		// When
+		const wrapper = mount(<AddFacetPopover {...props} />);
+
+		// Then
+		expect(wrapper.find('.tc-add-facet-popover-row-text').at(0).text()).toEqual('Connection name');
+		expect(wrapper.find('.tc-add-facet-popover-row-text').at(1).text()).toEqual('Custom attributes');
+		expect(wrapper.find('.tc-add-facet-popover-row-text').at(2).text()).toEqual('Name');
+	});
+	it('should not sort if null is provided as comparator', () => {
+		// Given
+		const props = {
+			badges,
+			badgesDefinitions,
+			id: 'my id',
+			onClick: jest.fn(),
+			badgesDefinitionsSort: null,
+			t,
+		};
+		// When
+		const wrapper = mount(<AddFacetPopover {...props} />);
+
+		// Then
+		expect(wrapper.find('.tc-add-facet-popover-row-text').at(0).text()).toEqual('Name');
+		expect(wrapper.find('.tc-add-facet-popover-row-text').at(1).text()).toEqual('Connection name');
+		expect(wrapper.find('.tc-add-facet-popover-row-text').at(2).text()).toEqual('Custom attributes');
+	});
 });

--- a/src/components/BasicSearch/BasicSearch.component.js
+++ b/src/components/BasicSearch/BasicSearch.component.js
@@ -42,6 +42,7 @@ const BasicSearch = ({
 	onSubmit,
 	setBadgesFaceted,
 	callbacks,
+	badgesDefinitionsSort,
 }) => {
 	const { id, t } = useFacetedSearchContext();
 	const operatorsDictionary = useMemo(() => createOperatorsDict(t, customOperatorsDictionary), [
@@ -54,7 +55,7 @@ const BasicSearch = ({
 	const badges = useMemo(
 		() => filterBadgeDefinitionsWithDictionary(badgesDictionary, badgesDefinitions),
 		[badgesDictionary, badgesDefinitions],
-	);
+		);
 	const [state, dispatch] = useFacetedBadges(badgesFaceted, setBadgesFaceted);
 	const quicksearchable = useMemo(
 		() => badgesDefinitions.filter(({ metadata = {} }) => metadata.isAvailableForQuickSearch),
@@ -126,6 +127,7 @@ const BasicSearch = ({
 							<AddFacetPopover
 								badges={state.badges}
 								badgesDefinitions={badges}
+								badgesDefinitionsSort={badgesDefinitionsSort}
 								id={basicSearchId}
 								initialFilterValue={initialFilterValue}
 								onClick={onClickOverlayRow(setOverlayOpened)}
@@ -155,6 +157,7 @@ const BasicSearch = ({
 
 BasicSearch.propTypes = {
 	badgesDefinitions: badgesFacetedPropTypes,
+	badgesDefinitionsSort: PropTypes.func,
 	badgesFaceted: PropTypes.shape({
 		badges: badgesFacetedPropTypes,
 	}),

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -2,25 +2,25 @@
 
 ### Table of Contents
 
-1. Main components  
-   a. [AddFacetPopover](#AddFacetPopover)  
-   b. [AdvancedSearch](#AdvancedSearch)  
-   c. [BasicSearch](#BasicSearch)  
-   d. [FacetedManager](#FacetedManager)  
-   e. [FacetedSearch](#FacetedSearch)  
-   f. [FacetedSearchIcon](#FacetedSearchIcon)  
+1. Main components
+   a. [AddFacetPopover](#AddFacetPopover)
+   b. [AdvancedSearch](#AdvancedSearch)
+   c. [BasicSearch](#BasicSearch)
+   d. [FacetedManager](#FacetedManager)
+   e. [FacetedSearch](#FacetedSearch)
+   f. [FacetedSearchIcon](#FacetedSearchIcon)
    g. [FacetedToolbar](#FacetedToolbar)
 2. Badges
    a. [BadgeText](#BadgeText)
    b. [BadgeNumber](#BadgeNumber)
    c. [BadgeCheckboxes](#BadgeCheckboxes)
 3. Badges api
-   a. [BadgeOperatorOverlay](#BadgeOperatorOverlay)  
-   b. [BadgesGenerator](#BadgesGenerator)  
-   c. [BadgeFaceted](#BadgeFaceted)  
+   a. [BadgeOperatorOverlay](#BadgeOperatorOverlay)
+   b. [BadgesGenerator](#BadgesGenerator)
+   c. [BadgeFaceted](#BadgeFaceted)
    d. [BadgeOverlay](#BadgeOverlay)
 4. Context
-   a. [FacetedSearchContext](#FacetedSearchContext)  
+   a. [FacetedSearchContext](#FacetedSearchContext)
    b. [BadgeFacetedContext](#BadgeFacetedContext)
 5. [Structure and PropTypes](##Structure and PropTypes)
    a. [BadgeDefinition](#BadgeDefinition)
@@ -60,9 +60,9 @@ The advanced search enable a **text input** field where the user can directly en
 ### BasicSearch
 
 This is **search with badges**.
-All the **logical behavior** of badges is embedded in this component ([facetedBadges.hook](#facetedBadges.hook)).  
+All the **logical behavior** of badges is embedded in this component ([facetedBadges.hook](#facetedBadges.hook)).
 You have to feed him with some **badges definitions** to allow the creation and the CRUD manipulation of badges.
-It triggers a submit every time the badges change.  
+It triggers a submit every time the badges change.
 Init the **badgeFaceted context** (see [BadgeFacetedContext](#BadgeFacetedContext)).
 
 | Props                     | Type                              | Info                                                                    |
@@ -74,6 +74,8 @@ Init the **badgeFaceted context** (see [BadgeFacetedContext](#BadgeFacetedContex
 | initialFilterValue        | string                            | filter value at first render of the [AddFacetPopover](#AddFacetPopover) |
 | onSubmit                  | func                              | callback trigger when badges change                                     |
 | setFacetedBadges          | func                              | callback trigger to sync the badges at every state change               |
+| badgesDefinitionsSort     | func                              | "Add filter" entries comparator, falls back to label sort               |
+
 
 ---
 
@@ -226,9 +228,9 @@ You have to provide the badges dictionary and the function to access it.
 
 ### BadgeFaceted
 
-The generic component at the based of **all badges**.  
+The generic component at the based of **all badges**.
 Create a badge (base on ui/badges) with a **category**, an **operator**, a **value** button which open a custom **popover**,
-and a **delete action** represents by a cross.  
+and a **delete action** represents by a cross.
 Popover flow mechanics is handle by [BadgeOpenedOverlayFlow](#BadgeOpenedOverlayFlow).
 
 | Props                 | Type               | Info                                         |
@@ -251,7 +253,7 @@ Popover flow mechanics is handle by [BadgeOpenedOverlayFlow](#BadgeOpenedOverlay
 ### BadgeOverlay
 
 Create a **button icon** with a **popover**.
-Depending on props the button will be a icon, a label or "+ Add Filter".  
+Depending on props the button will be a icon, a label or "+ Add Filter".
 Worked in **uncontrolled mode**.
 Render the **children** you pass as a React.element or as a function if you need to access the opened value outside.
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

"Add filters" are sort by label, which we may not want

**What is the chosen solution to this problem?**

Added ability to provided null or a custom comparator

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
