### PR TITLE
feat: ability to customize the quicksearch placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Types of changes
 
 ## [unreleased]
 
+### Added
+
+- Ability to customize the quicksearch placeholder
+
 ## [3.1.0]
 
 ### Added

--- a/src/components/Badges/BadgeSlider/BadgeSliderForm.component.js
+++ b/src/components/Badges/BadgeSlider/BadgeSliderForm.component.js
@@ -76,7 +76,7 @@ const BadgeSliderForm = ({
 		<form className={theme('tc-badge-slider-form')} id={`${id}-slider`} onSubmit={onSubmit}>
 			<Rich.Layout.Body id={`${id}-badge-body`} className={theme('tc-badge-slider-form-body')}>
 				<div className={theme('tc-badge-slider-form-body-row')}>
-					{icon && <Icon name={icon.name} className={theme('tc-badge-icon', icon.class)} />}
+					{icon && <Icon name={icon.name} className={theme('tc-badge-icon', icon.class || icon.className)} />}
 					{editing ? (
 						<input
 							id={`${id}-input`}
@@ -157,6 +157,7 @@ BadgeSliderForm.propTypes = {
 	icon: PropTypes.shape({
 		name: PropTypes.string,
 		class: PropTypes.string,
+		className: PropTypes.string,
 	}),
 	operator: PropTypes.shape({
 		name: PropTypes.string,

--- a/src/components/BasicSearch/BasicSearch.component.js
+++ b/src/components/BasicSearch/BasicSearch.component.js
@@ -43,6 +43,7 @@ const BasicSearch = ({
 	setBadgesFaceted,
 	callbacks,
 	badgesDefinitionsSort,
+	quickSearchPlaceholder,
 }) => {
 	const { id, t } = useFacetedSearchContext();
 	const operatorsDictionary = useMemo(() => createOperatorsDict(t, customOperatorsDictionary), [
@@ -87,6 +88,7 @@ const BasicSearch = ({
 				t={t}
 				className={css('tc-basic-search-quicksearch')}
 				facets={quicksearchable}
+				placeholder={quickSearchPlaceholder}
 				onSelect={(facet, value) => {
 					const operators = getOperatorsFromDict(
 						operatorsDictionary,
@@ -164,6 +166,7 @@ BasicSearch.propTypes = {
 	customBadgesDictionary: PropTypes.object,
 	customOperatorsDictionary: operatorsPropTypes,
 	initialFilterValue: PropTypes.string,
+	quickSearchPlaceholder: PropTypes.string,
 	onSubmit: PropTypes.func.isRequired,
 	setBadgesFaceted: PropTypes.func,
 	callbacks: callbacksPropTypes,

--- a/src/components/QuickSearchInput/QuickSearchInput.component.js
+++ b/src/components/QuickSearchInput/QuickSearchInput.component.js
@@ -10,7 +10,7 @@ export const DEFAULT_QUICKSEARCH_OPERATOR = 'containsIgnoreCase';
 const getDefaultFacet = (facets = []) =>
 	facets.find(({ metadata }) => metadata.isDefaultForQuickSearch) || facets[0];
 
-export const QuickSearchInput = ({ t, facets, className, onSelect = () => {} }) => {
+export const QuickSearchInput = ({ t, facets, placeholder, className, onSelect = () => {} }) => {
 	const defaultFacet = useMemo(() => getDefaultFacet(facets), [facets]);
 	const [opened, setOpened] = useState(false);
 	const [value, setValue] = useState('');
@@ -21,7 +21,7 @@ export const QuickSearchInput = ({ t, facets, className, onSelect = () => {} }) 
 
 	return (
 		<Typeahead
-			placeholder={t('QUICKSEARCH_PLACEHOLDER', { defaultValue: 'Find in a column...' })}
+			placeholder={placeholder || t('QUICKSEARCH_PLACEHOLDER', { defaultValue: 'Find in a column...' })}
 			onFocus={() => setOpened(value.length >= MINIMUM_LENGTH)}
 			onBlur={() => {
 				setValue('');
@@ -63,6 +63,7 @@ export const QuickSearchInput = ({ t, facets, className, onSelect = () => {} }) 
 QuickSearchInput.propTypes = {
 	facets: badgesFacetedPropTypes,
 	className: PropTypes.string,
+	placeholder: PropTypes.string,
 	onSelect: PropTypes.func,
 	t: PropTypes.func,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Quicksearch placeholder is hardcoded 

**What is the chosen solution to this problem?**

Add a new optional quickSearchPlaceholder prop

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
