### PR TITLE
feat: add initial badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Types of changes
 
 ## [unreleased]
 
+## [3.4.0]
+
+### Added
+
+- Add initial badges support
 
 ## [3.3.3]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-faceted-search",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "Faceted search",
   "main": "lib/index.js",
   "mainSrc": "src/index.js",

--- a/src/components/BasicSearch/BasicSearch.component.js
+++ b/src/components/BasicSearch/BasicSearch.component.js
@@ -36,6 +36,7 @@ const isInCreation = badge => get(badge, 'metadata.isInCreation', true);
 const BasicSearch = ({
 	badgesDefinitions = [],
 	badgesFaceted,
+	initialBadgesFaceted = [],
 	customBadgesDictionary,
 	customOperatorsDictionary,
 	initialFilterValue,
@@ -56,7 +57,7 @@ const BasicSearch = ({
 	const badges = useMemo(
 		() => filterBadgeDefinitionsWithDictionary(badgesDictionary, badgesDefinitions),
 		[badgesDictionary, badgesDefinitions],
-		);
+	);
 	const [state, dispatch] = useFacetedBadges(badgesFaceted, setBadgesFaceted);
 	const quicksearchable = useMemo(
 		() => badgesDefinitions.filter(({ metadata = {} }) => metadata.isAvailableForQuickSearch),
@@ -68,6 +69,25 @@ const BasicSearch = ({
 			onSubmit({}, state.badges);
 		}
 	}, [state.badges, onSubmit]);
+
+	useEffect(() => {
+		initialBadgesFaceted.forEach(initial => {
+			const facet = badges.find(
+				({ properties }) => properties.attribute === initial.attribute,
+			);
+			const operators = getOperatorsFromDict(
+				operatorsDictionary,
+				get(facet, 'metadata.operators'),
+			);
+			dispatch(
+				BADGES_ACTIONS.addWithValue(
+					generateBadge(operators)(facet),
+					operatorsDictionary[initial.operator],
+					initial.value,
+				),
+			);
+		});
+	}, []);
 
 	const onClickOverlayRow = setOverlayOpened => (_, badgeDefinition) => {
 		const operators = getOperatorsFromDict(
@@ -163,6 +183,7 @@ BasicSearch.propTypes = {
 	badgesFaceted: PropTypes.shape({
 		badges: badgesFacetedPropTypes,
 	}),
+	initialBadgesFaceted: badgesFacetedPropTypes,
 	customBadgesDictionary: PropTypes.object,
 	customOperatorsDictionary: operatorsPropTypes,
 	initialFilterValue: PropTypes.string,

--- a/src/components/BasicSearch/BasicSearch.component.js
+++ b/src/components/BasicSearch/BasicSearch.component.js
@@ -36,7 +36,7 @@ const isInCreation = badge => get(badge, 'metadata.isInCreation', true);
 const BasicSearch = ({
 	badgesDefinitions = [],
 	badgesFaceted,
-	initialBadgesFaceted = [],
+	initialBadges = [],
 	customBadgesDictionary,
 	customOperatorsDictionary,
 	initialFilterValue,
@@ -71,7 +71,7 @@ const BasicSearch = ({
 	}, [state.badges, onSubmit]);
 
 	useEffect(() => {
-		initialBadgesFaceted.forEach(initial => {
+		initialBadges.forEach(initial => {
 			const facet = badges.find(
 				({ properties }) => properties.attribute === initial.attribute,
 			);
@@ -183,7 +183,13 @@ BasicSearch.propTypes = {
 	badgesFaceted: PropTypes.shape({
 		badges: badgesFacetedPropTypes,
 	}),
-	initialBadgesFaceted: badgesFacetedPropTypes,
+	initialBadges: PropTypes.arrayOf(
+		PropTypes.shape({
+			attribute: PropTypes.string,
+			value: PropTypes.any,
+			operator: PropTypes.string,
+		}),
+	),
 	customBadgesDictionary: PropTypes.object,
 	customOperatorsDictionary: operatorsPropTypes,
 	initialFilterValue: PropTypes.string,

--- a/src/components/BasicSearch/BasicSearch.component.test.js
+++ b/src/components/BasicSearch/BasicSearch.component.test.js
@@ -101,7 +101,7 @@ describe('BasicSearch', () => {
 		// Given
 		const props = {
 			badgesDefinitions,
-			initialBadgesFaceted: [{
+			initialBadges: [{
 				attribute: 'name',
 				operator: '=',
 				value: 'hello'

--- a/src/components/BasicSearch/BasicSearch.component.test.js
+++ b/src/components/BasicSearch/BasicSearch.component.test.js
@@ -41,7 +41,10 @@ describe('BasicSearch', () => {
 			initialValueOpened: false,
 			label: 'Name',
 			operator: {},
-			operators: [],
+			operators: [
+				{ label: 'Equals', name: '=', iconName: 'equal' },
+				{ label: 'Contains', name: 'contains', iconName: 'contains' },
+			],
 			type: 'text',
 		},
 		metadata: {
@@ -93,6 +96,28 @@ describe('BasicSearch', () => {
 		// Then
 		expect(wrapper.html()).toMatchSnapshot();
 	});
+
+	it('should render the default html output with initial badges', () => {
+		// Given
+		const props = {
+			badgesDefinitions,
+			initialBadgesFaceted: [{
+				attribute: 'name',
+				operator: '=',
+				value: 'hello'
+			}],
+			onSubmit: jest.fn(),
+		};
+		// When
+		const wrapper = mount(
+			<FacetedManager id="manager-id">
+				<BasicSearch {...props} />
+			</FacetedManager>,
+		);
+		// Then
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
 	it('should render the default html output with some badges and the quick search input', () => {
 		// Given
 		const props = {

--- a/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
+++ b/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
@@ -1,5 +1,137 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BasicSearch should render the default html output with initial badges 1`] = `
+<div id="manager-id-basic-search"
+     class="tc-basic-search theme-tc-basic-search"
+>
+  <div role="combobox"
+       aria-haspopup="listbox"
+       aria-owns="react-autowhatever-42"
+       aria-expanded="false"
+       class="theme-tc-typeahead-container tc-typeahead-container tc-basic-search-quicksearch theme-tc-basic-search-quicksearch"
+  >
+    <div class="tc-typeahead-typeahead-input-icon theme-typeahead-input-container theme-typeahead-input-icon">
+      <label for="react-autowhatever-42-input"
+             class="control-label sr-only"
+      >
+        Search
+      </label>
+      <div class="icon-cls theme-icon-cls">
+        <svg name="talend-search"
+             class="theme-tc-svg-icon tc-svg-icon"
+             focusable="false"
+             aria-hidden="true"
+        >
+        </svg>
+      </div>
+      <input autocomplete="off"
+             aria-autocomplete="list"
+             aria-controls="react-autowhatever-42"
+             aria-activedescendant="react-autowhatever-42-section-0-item-0"
+             placeholder="Find in a column..."
+             role="searchbox"
+             type="text"
+             id="42"
+             class="theme-typeahead-input tc-typeahead-typeahead-input form-control"
+             value
+      >
+    </div>
+  </div>
+  <div class="tc-basic-search-content theme-tc-basic-search-content">
+    <div class="tc-badge theme-tc-badge tc-badge-display-large theme-tc-badge-display-large tc-badge-faceted theme-tc-badge-faceted theme-tc-badge-faceted theme-tc-badge-faceted tc-badge-readonly theme-tc-badge-readonly">
+      <div id="tc-badge-select-name-42-badge-text"
+           class="tc-badge-button theme-tc-badge-button"
+      >
+        <span aria-label="Name"
+              class="tc-badge-category theme-tc-badge-category"
+              aria-describedby="42"
+        >
+          Name
+        </span>
+        <div class="tc-badge-operator theme-tc-badge-operator tc-badge-operator-large theme-tc-badge-operator-large">
+          <div class="tc-badge-operator-button theme-tc-badge-operator-button">
+            <button id="name-42-badge-text-operator-action-overlay"
+                    aria-label="Contains"
+                    type="button"
+                    aria-describedby="42"
+                    class="btn btn-link"
+            >
+              <svg name="talend-contains"
+                   class="theme-tc-svg-icon tc-svg-icon tc-badge-link-plus-icon theme-tc-badge-link-plus-icon"
+                   focusable="false"
+                   aria-hidden="true"
+              >
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div class="tc-badge-faceted-overlay theme-tc-badge-faceted-overlay">
+          <button id="name-42-badge-text-action-overlay"
+                  aria-label="hello"
+                  type="button"
+                  class="btn btn-link"
+          >
+            <span>
+              hello
+            </span>
+          </button>
+        </div>
+        <button role="button"
+                aria-label="Remove filter"
+                id="tc-badge-delete-name-42-badge-text"
+                data-feature="filter.remove"
+                aria-describedby="42"
+                type="button"
+                class="tc-badge-delete-icon theme-tc-badge-delete-icon btn-icon-only btn btn-link"
+        >
+          <svg name="talend-cross"
+               class="theme-tc-svg-icon tc-svg-icon"
+               focusable="false"
+               aria-hidden="true"
+          >
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div>
+      <button id="manager-id-basic-search-action-overlay"
+              aria-label="Add filter"
+              type="button"
+              data-feature="filter.basic.add"
+              aria-describedby="42"
+              class="tc-badge-link-plus theme-tc-badge-link-plus btn btn-link"
+      >
+        <svg name="talend-plus-circle"
+             class="theme-tc-svg-icon tc-svg-icon tc-badge-link-plus-icon theme-tc-badge-link-plus-icon"
+             focusable="false"
+             aria-hidden="true"
+        >
+        </svg>
+        <span>
+          Add filter
+        </span>
+      </button>
+    </div>
+  </div>
+  <button role="link"
+          aria-label="Remove all filters"
+          data-feature="filter.basic.clear"
+          aria-describedby="42"
+          type="button"
+          class="tc-basic-search-clear-button theme-tc-basic-search-clear-button btn-icon-only btn btn-link"
+  >
+    <svg name="talend-trash"
+         class="theme-tc-svg-icon tc-svg-icon"
+         focusable="false"
+         aria-hidden="true"
+    >
+    </svg>
+    <span>
+    </span>
+  </button>
+</div>
+`;
+
 exports[`BasicSearch should render the default html output with no badges 1`] = `
 <div id="manager-id-basic-search"
      class="tc-basic-search theme-tc-basic-search"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

It is not possible to set initial badges as it is possible to do for the advanced mode. Furthermore, we wanted to find a way to store lighter payloads.

**What is the chosen solution to this problem?**

 `initialBadges` is an array of object which have three properties : `value`, `operator` (`propertiers.operators[].name`), and `attribute`. 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
