### PR TITLE
chore: Remove faceted search developpement mode  warning

### DIFF
--- a/src/components/FacetedSearch/FacetedSearch.component.js
+++ b/src/components/FacetedSearch/FacetedSearch.component.js
@@ -7,10 +7,6 @@ import { FacetedManager } from '../FacetedManager';
 import { controlled } from '../../controlled';
 
 const FacetedSearch = ({ children, error, facetedMode, id, inProgress, setFacetedMode }) => {
-	console.warn(
-		'WARNING ABOUT FACETED SEARCH: The faceted search stills in development, so it could have some breaking change during this phase. The component will not follow the ui release process',
-	);
-
 	const isControlled = controlled('FacetedSearch', facetedMode, setFacetedMode);
 	const [facetedModeState, setFacetedModeState] = useState(FACETED_MODE.BASIC);
 	const { t } = useTranslation(I18N_DOMAIN_FACETED_SEARCH);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Reduce warning in console to improve developer xp.
In the early stage of the faceted search creation, we have a warning to alert to user of the development phase. 

![warning](https://user-images.githubusercontent.com/52413026/127988156-aeb7bb30-ea43-4319-83d1-a649d0ecfa96.png)

Package is now in version 3.X.X and used in production, we can remove it.

**What is the chosen solution to this problem?**
Remove it.


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
