### PR TITLE
chore: Add script for build dev in umd

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "prepublishOnly": "talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
     "prepare": "talend-scripts build:lib",
+    "build:dev": "talend-scripts build:lib:umd --dev",
     "test": "cross-env TZ=Europe/Paris talend-scripts test --silent",
     "test:watch": "cross-env TZ=Europe/Paris talend-scripts test --watch",
     "test:cov": "cross-env TZ=Europe/Paris talend-scripts test --coverage",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When we try to use the faceted-search package in a local context with an app that use the umd build, we can't have produce a umd build for dev.

This PR introduce a new script for umd dev build.

**What is the chosen solution to this problem?**
Just add a new script in `package.json` to trigger the build in dev mode with an umd target.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
