### PR TITLE
feat(BadgeFaceted): Expose component to create custom badge outside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Types of changes
 
 -   Fix translation key
 
+### Added
+
+-   Expose BadgeFaceted to create custom badge outside the library
+
 ## [3.4.1]
 
 ### Security

--- a/src/components/Badges/index.js
+++ b/src/components/Badges/index.js
@@ -1,6 +1,7 @@
 import { BadgeText } from './BadgeText';
 import { BadgeSlider } from './BadgeSlider';
 import { BadgeOverlay } from './BadgeOverlay';
+import { BadgeFaceted } from './BadgeFaceted';
 import { BadgeCheckboxes, BadgeCheckboxesForm } from './BadgeCheckboxes';
 
-export { BadgeText, BadgeSlider, BadgeOverlay, BadgeCheckboxes, BadgeCheckboxesForm };
+export { BadgeText, BadgeSlider, BadgeOverlay, BadgeCheckboxes, BadgeCheckboxesForm, BadgeFaceted };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,7 +2,14 @@ import { FacetedSearchIcon } from './FacetedSearchIcon';
 import { FacetedSearch } from './FacetedSearch';
 import { AdvancedSearch } from './AdvancedSearch';
 import { BasicSearch } from './BasicSearch';
-import { BadgeText, BadgeSlider, BadgeOverlay, BadgeCheckboxes, BadgeCheckboxesForm } from './Badges';
+import {
+	BadgeText,
+	BadgeSlider,
+	BadgeOverlay,
+	BadgeCheckboxes,
+	BadgeCheckboxesForm,
+	BadgeFaceted,
+} from './Badges';
 import * as badgeDefinitionTypes from './types/badgeDefinition.type';
 
 export {
@@ -16,4 +23,5 @@ export {
 	BadgeOverlay,
 	BadgeCheckboxes,
 	BadgeCheckboxesForm,
+	BadgeFaceted,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,11 @@ import {
 	BadgeOverlay,
 	BadgeCheckboxes,
 	BadgeCheckboxesForm,
+	BadgeFaceted,
 } from './components';
 import * as constants from './constants';
 import dictionaryHelpers from './dictionary/helpers.dictionary';
 import * as queryClient from './queryClient';
-
 
 const components = {
 	Icon,
@@ -25,6 +25,7 @@ const components = {
 	BadgeOverlay,
 	BadgeCheckboxes,
 	BadgeCheckboxesForm,
+	BadgeFaceted,
 };
 
 const helpers = {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Faceted search can handle custom badge in `<BasicSearch />` with an existing `customBadgesDictionary` props.
But we need the `<BadgeFaceted />` (a generic wrapper component for badge) to be exposed.

**What is the chosen solution to this problem?**
Just go down the component through folder to the main `index.js`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
